### PR TITLE
fix: remove blocking loader overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,12 +149,6 @@
     </div>
   </div>
 
-  <!-- Non-blocking Loader Overlay at the end of body -->
-  <div id="loaderOverlay" role="dialog" aria-hidden="true" class="hidden" tabindex="-1">
-    <div id="loadingLogo" data-i18n-key="loading" aria-label="loading"></div>
-    <button id="loaderCloseBtn" role="button" aria-label="closeLoader">×</button>
-  </div>
-
   <!-- Important: scripts (module, non-blocking) -->
   <script type="module" src="./app.js"></script>
   <script type="module" src="./ui_bootstrap.js"></script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --mode dev",
     "build": "vite build",
-    "lint": "echo 'linted'"
+    "lint": "echo 'linted'",
+    "test": "node tests/no-loader.test.js"
   },
   "keywords": [],
   "author": "",

--- a/styles.css
+++ b/styles.css
@@ -331,50 +331,6 @@ header p {
   transition: all 0.3s ease;
 }
 
-/* === LOADER OVERLAY (Non-blocking) === */
-#loaderOverlay {
-  position: fixed;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  background: rgba(0,0,0,.6);
-  z-index: 9999;
-  opacity: 1;
-  visibility: visible;
-  pointer-events: none; /* Non-blocking: allow clicks to pass through */
-}
-#loadingLogo {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  border: 6px solid rgba(255,255,255,0.15);
-  border-top-color: var(--primary-accent);
-  animation: loader-spin 1s linear infinite;
-  box-shadow: 0 0 20px rgba(0,0,0,0.35);
-}
-@keyframes loader-spin {
-  to { transform: rotate(360deg); }
-}
-#loaderCloseBtn {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  font-size: 1.5rem;
-  background: transparent;
-  border: 2px solid rgba(255,255,255,0.25);
-  color: #fff;
-  line-height: 1;
-  border-radius: 8px;
-  width: 40px;
-  height: 40px;
-  cursor: pointer;
-  pointer-events: auto; /* Keep the "×" clickable even when overlay is non-intercepting */
-}
-#loaderCloseBtn:hover {
-  background: rgba(255,255,255,0.1);
-  border-color: var(--primary-accent);
-}
-
 /* Responsive */
 @media (max-width: 900px) {
     body { padding: 10px; padding-bottom: 80px; }

--- a/tests/no-loader.test.js
+++ b/tests/no-loader.test.js
@@ -1,0 +1,12 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const htmlPath = path.join(__dirname, '..', 'index.html');
+const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+
+if (htmlContent.includes('id="loaderOverlay"')) {
+  console.error('Loader overlay markup still present in index.html');
+  process.exit(1);
+}
+
+console.log('Loader overlay markup removed successfully.');


### PR DESCRIPTION
## Summary
- remove the loader overlay markup so the player is visible immediately
- delete the associated styling that forced the overlay to cover the page
- add a regression test and npm script to ensure the overlay markup is not reintroduced

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e3f915b7548322a624fae5dcbd116a