### PR TITLE
feat: add daremon logo overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,22 @@
 <body data-theme="arburg">
   <!-- Visualizer -->
   <canvas id="visualizer-canvas"></canvas>
+  <div id="daremon-logo" role="img" aria-label="DAREMON ETS logo">
+    <svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+      <title>DAREMON ETS logo</title>
+      <defs>
+        <radialGradient id="logo-glow" cx="50%" cy="50%" r="60%">
+          <stop offset="0%" stop-color="#00a58a" stop-opacity="0.9" />
+          <stop offset="70%" stop-color="#00a58a" stop-opacity="0.2" />
+          <stop offset="100%" stop-color="#00a58a" stop-opacity="0" />
+        </radialGradient>
+      </defs>
+      <circle cx="120" cy="120" r="100" fill="rgba(0, 0, 0, 0.65)" stroke="#00a58a" stroke-width="4" />
+      <circle cx="120" cy="120" r="118" fill="url(#logo-glow)" />
+      <text x="50%" y="45%" text-anchor="middle" font-size="48" font-family="'Orbitron', sans-serif" fill="#D4FF3D" letter-spacing="4">DAREMON</text>
+      <text x="50%" y="65%" text-anchor="middle" font-size="28" font-family="'Orbitron', sans-serif" fill="#FFFFFF" letter-spacing="6">ETS</text>
+    </svg>
+  </div>
   <div id="offline-indicator" class="hidden" aria-live="assertive" data-i18n-key="offlineMessage"></div>
 
   <div id="app-container">

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,27 @@ body {
     pointer-events: none;
 }
 
+#daremon-logo {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: clamp(180px, 22vw, 320px);
+    aspect-ratio: 1;
+    pointer-events: none;
+}
+
+#daremon-logo svg,
+#daremon-logo img {
+    width: 100%;
+    height: auto;
+    filter: drop-shadow(0 0 12px rgba(0, 165, 138, 0.45));
+}
+
 /* Animations */
 @keyframes neon-flicker {
     0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% {
@@ -112,6 +133,8 @@ body {
 
 /* Layout */
 #app-container {
+    position: relative;
+    z-index: 2;
     width: 100%;
     max-width: 1200px;
     display: flex;


### PR DESCRIPTION
## Summary
- add a dedicated Daremon logo overlay element directly after the visualizer canvas
- style the overlay for centered positioning with responsive sizing and ensure stacking below interactive UI

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e40e9e9ca883228095386a824721f2