### PR TITLE
fix: align visualizer canvas styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -72,7 +72,7 @@ body {
 }
 
 /* Visualizer */
-#visualizer {
+#visualizer-canvas {
     position: fixed;
     top: 0; left: 0;
     width: 100%; height: 100%;


### PR DESCRIPTION
## Summary
- replace the obsolete #visualizer selector with #visualizer-canvas to match the rendered canvas
- retain fixed full-viewport positioning, negative stacking context, and disabled pointer events so the canvas stays behind the UI

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e40e9934f883228524dedf5b7c3b1e